### PR TITLE
Añadidas dos temáticas y eliminada la opción de álbumes

### DIFF
--- a/webapp/src/components/GameMode/GameMode.js
+++ b/webapp/src/components/GameMode/GameMode.js
@@ -10,8 +10,9 @@ const GameMode = () => {
   const gameModes = [
     { label: 'Ciudades', value: 'city' },
     { label: 'Banderas', value: 'flag' },
-    { label: 'Álbumes', value: 'album' },
     { label: 'Fútbol', value: 'football' },
+    { label: 'Música', value: 'music'},
+    { label: 'Comida', value: 'food'}
   ];
 
   const difficulties = ['Fácil', 'Media', 'Difícil'];

--- a/webapp/src/components/GameMode/GameMode.test.js
+++ b/webapp/src/components/GameMode/GameMode.test.js
@@ -16,8 +16,9 @@ describe('GameMode component', () => {
     expect(screen.getByText(/Selecciona el modo de juego/i)).toBeInTheDocument();
     expect(screen.getByText(/Ciudades/i)).toBeInTheDocument();
     expect(screen.getByText(/Banderas/i)).toBeInTheDocument();
-    expect(screen.getByText(/Álbumes/i)).toBeInTheDocument();
+    expect(screen.getByText(/Música/i)).toBeInTheDocument();
     expect(screen.getByText(/Fútbol/i)).toBeInTheDocument();
+    expect(screen.getByText(/Comida/i)).toBeInTheDocument();
 
     // Verificar los botones de dificultad
     expect(screen.getByText(/Selecciona la dificultad/i)).toBeInTheDocument();

--- a/wikiservice/wiki-service.js
+++ b/wikiservice/wiki-service.js
@@ -42,6 +42,23 @@ const queries = [{
       '?answer wdt:P31 wd:Q6256;' +
       '         wdt:P41 ?image.' +
       ' SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],es,en". }} LIMIT 100'
+}, {
+  kind: "music",
+  question: "¿Qué grupo es?",
+  query: 'SELECT ?answerLabel ?image WHERE {' +
+      '?answer wdt:P31 wd:Q215380;' +
+      '         wdt:P18 ?image;' +
+      '         wdt:P166 ?award.' +
+      'SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],es,en". }} LIMIT 100'
+}, {
+  kind: "food",
+  question: "¿Qué plato de comida es?",
+  query: 'SELECT ?answerLabel ?image WHERE {' +
+      '?answer wdt:P31 wd:Q2095;' +
+      '       wdt:P18 ?image;' +
+      '       wdt:P495 ?country.' +
+      'FILTER(?country IN (wd:Q29, wd:Q38, wd:Q142))' +
+      'SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],es,en". }} LIMIT 100'
 }];
 
 function getQuery(kind) {


### PR DESCRIPTION
Añadidas dos temáticas para contrarrestar la temática de álbumes, que la eliminamos por que el título del álbum tiende a estar incluido en la imagen