### PR TITLE
Evitar que las imágenes de la app sean arrastrables

### DIFF
--- a/webapp/src/components/ContestHistory/ContestHistory.js
+++ b/webapp/src/components/ContestHistory/ContestHistory.js
@@ -80,7 +80,7 @@ const ContestHistory = () => {
             alignItems: 'center',
             justifyContent: 'center',
           }}>
-            <img src={question.image} alt="Imagen de la pregunta" className="responsive-img" />
+            <img src={question.image} alt="Imagen de la pregunta" className="responsive-img" draggable="false"/>
             <HistoryText size="h6">
               {`Pregunta: ${question.question}`}
             </HistoryText>

--- a/webapp/src/components/Game/Game.js
+++ b/webapp/src/components/Game/Game.js
@@ -286,7 +286,7 @@ const handleRestart = () => {
               </Box>
               {imagenPregunta && (
                 <Box className="image-container">
-                  <img src={imagenPregunta} alt="Imagen de la pregunta" className="responsive-img" />
+                  <img src={imagenPregunta} alt="Imagen de la pregunta" className="responsive-img" draggable="false"/>
                 </Box>
               )}
               <Grid container spacing={2} className="button-container">

--- a/webapp/src/components/NavBar/NavBar.js
+++ b/webapp/src/components/NavBar/NavBar.js
@@ -46,7 +46,7 @@ const NavigationBar = () => {
     <div id="navbar">
       <AppBar id="appbar" position="absolute">
         <Tabs id="tabsContainer" aria-label="navigation tabs" value={false} variant="fullWidth">
-          <Tab id="logo" aria-label="Logo" data-testid="logo-tab" icon={<Tooltip title="Home"><img src={IconWichat} alt="Icono" /></Tooltip>} onClick={showHome}/>
+          <Tab id="logo" aria-label="Logo" data-testid="logo-tab" icon={<Tooltip title="Home"><img src={IconWichat} alt="Icono" draggable="false"/></Tooltip>} onClick={showHome}/>
           <Tab id="wichat" label="WiChat" data-testid="wichat-tab" sx={tabStyle} onClick={showHome} />
           <div style={{ flex: 7 }} />
           <Tab id='profile' label="Profile" data-testid="profile-tab" onClick={showProfile} />


### PR DESCRIPTION
Eliminada la opción de que las imágenes se puedan arrastrar