### PR TITLE
Limitado uso llm, y resta de puntos por su uso

### DIFF
--- a/webapp/src/components/Game/Game.js
+++ b/webapp/src/components/Game/Game.js
@@ -41,7 +41,7 @@ const Juego = () => {
   const [numPreguntas, setNumPreguntas] = useState(0)
   const [loadingProgress, setLoadingProgress] = useState(0);
   const [loadingComplete, setLoadingComplete] = useState(false);
-  const [points] = useState(0)
+  const [points, setPoints] = useState(0); // Estado para manejar la puntuación
   const [tiempoRestante, setTiempoRestante] = useState(20); // Tiempo inicial del temporizador
   const [arTiempo] = useState([]); // Array para almacenar el tiempo restante
   const [numPistas, setNumPistas] = useState(0); // Número de pistas solicitadas
@@ -49,6 +49,8 @@ const Juego = () => {
   const [arCorrect] = useState([]); // Array para almacenar las respuestas correctas
   const [mostrarChat, setMostrarChat] = useState(false);
   const location = useLocation();
+  const [botonPistaHabilitado, setBotonPistaHabilitado] = useState(true); 
+  const [botonChatHabilitado, setBotonChatHabilitado] = useState(true);
   const { mode = 'flag', difficulty = t("easy") } = location.state || {};
 
     // Estados para el LLM
@@ -116,9 +118,11 @@ const Juego = () => {
       }
     }, [firstRender, crearPreguntas, difficulty, mode, t]);
 
-  // Función para enviar una solicitud al LLM y obtener una pista
   const enviarRespuestaALlm = async () => {
+    if (!botonPistaHabilitado) return; // Evitar múltiples ejecuciones
+    setBotonPistaHabilitado(false); // Deshabilitar el botón de pista
     setNumPistas(numPistas + 1);
+    setPoints((prevPoints) => prevPoints - 20); // Restar 20 puntos por usar la pista
     try {
       const response = await axios.post(`${apiEndpoint}/askllm`, {
           question: "",
@@ -146,6 +150,7 @@ const Juego = () => {
       //Aumenta en 1 en las estadisticas de juegos ganado
       arCorrect.push(true);
       setNumRespuestasCorrectas(numRespuestasCorrectas+1);
+      setPoints((prevPoints) => prevPoints + 100);
     } else {
       arCorrect.push(false);
     }
@@ -224,7 +229,8 @@ const Juego = () => {
       navigate('/points', {
         state: {
           numRespuestasCorrectas: numRespuestasCorrectas,
-          numPreguntas: numPreguntas
+          numPreguntas: numPreguntas,
+          points: points,
         }
       });
       return;
@@ -241,10 +247,18 @@ const Juego = () => {
     setPausarTemporizador(false);
     setMostrarChat(false);
     setRespuestaLLM("");
-  };
+};
 
   const handleRestart = () => {
     setRestartTemporizador(false); // Cambia el estado de restart a false, se llama aqui desde Temporizador.js
+  };
+
+  // Función para manejar el botón del chat
+  const toggleChat = () => {
+    if (!botonChatHabilitado) return; // Evitar múltiples ejecuciones
+    setBotonChatHabilitado(false); // Deshabilitar el botón del chat
+    setPoints((prevPoints) => prevPoints - 40); // Restar 40 puntos por usar el chat
+    setMostrarChat(!mostrarChat);
   };
 
   return (
@@ -261,7 +275,7 @@ const Juego = () => {
           {/* Columna izquierda */}
           <Grid item xs={12} md={3}>
             <Stack spacing={2}>
-              <Button id="botonPista" variant="contained" onClick={enviarRespuestaALlm} disabled={!loadingComplete}>
+              <Button id="botonPista" variant="contained" onClick={enviarRespuestaALlm} disabled={!botonPistaHabilitado || !loadingComplete}>
                 {t("need-clue")}
               </Button>
               {respuestaLLM && (
@@ -269,7 +283,7 @@ const Juego = () => {
                   <strong>{t("llm-response")}:</strong> {respuestaLLM}
                 </Box>
               )}
-             <Button id="botonChat" variant="contained" onClick={() => setMostrarChat(!mostrarChat)}>
+             <Button id="botonChat" variant="contained" onClick={toggleChat} disabled={!botonChatHabilitado || !loadingComplete}>
                 {mostrarChat ? t("close-chat") : t("chat")}
               </Button>
               {mostrarChat && (
@@ -325,7 +339,7 @@ const Juego = () => {
                 />
               </Box>
               <Box className="puntuacion-info-container" p={2} border="1px solid #ccc" borderRadius="5px">
-                {t("punctuation")}: {numRespuestasCorrectas * 100}
+                {t("punctuation")}: {points}
               </Box>
               <Button id="botonSiguiente" variant="contained" onClick={clickSiguiente} disabled={!loadingComplete}>
                 {t("next-question")}


### PR DESCRIPTION
Se ha deshabilitado el botón de pista, y el chat con el llm tras el primer uso de cada componente, Además, se ha añadido una disminución de la puntuación tras usar estos dos componentes. -40 puntos tras usar el chat y -20 puntos tras usar el botón de pista. Se podría cambiar de ser necesario. Además he cambiado la forma de manejar la puntuación, ya no es 100*respuesta correcta, si no que al acertar se suman 100 puntos