### PR TITLE
Quitada duracion de los token

### DIFF
--- a/users/authservice/auth-service.js
+++ b/users/authservice/auth-service.js
@@ -53,7 +53,6 @@ app.post('/login',  [
       const token = jwt.sign(
         { user: user }, 
         'your-secret-key', 
-        { expiresIn: '1h' }
       );
       // Respond with the token and user information
       res.json({ token: token, username: username, createdAt: user.createdAt });

--- a/users/userservice/user-service.js
+++ b/users/userservice/user-service.js
@@ -269,7 +269,6 @@ app.post('/adduser', async (req, res) => {
       const token = jwt.sign(
               { user: newUser }, 
               'your-secret-key', 
-              { expiresIn: '1h' }
             );
 
       await newUser.save();


### PR DESCRIPTION
Se ha quitado en "expiresIn" para evitar bugs con la aplicación, ya que no se controla adecuadamente la caducidad de los tokens