### PR TITLE
Cambiado el dockerfile de prometheus por un error en su configuración

### DIFF
--- a/gatewayservice/monitoring/prometheus/Dockerfile
+++ b/gatewayservice/monitoring/prometheus/Dockerfile
@@ -2,7 +2,7 @@
 FROM prom/prometheus:latest
 
 # Copy Prometheus configuration
-COPY . .
+COPY prometheus.yml /etc/prometheus/prometheus.yml
 
 # Expose the port
 EXPOSE 9090


### PR DESCRIPTION
Se ha cambiado la configuración de prometheus en el dockerfile porque no funciona al desplegar la app, creemos que esta línea puede solucionar ese problema